### PR TITLE
Fix minor portability issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,8 @@ val buildSettings = Seq(
   fork := true,
   resolvers += Resolver.typesafeRepo("releases"),
   resolvers += Resolver.sonatypeRepo("releases"),
-  resolvers += sbtResolver.value
+  resolvers += sbtResolver.value,
+  resolvers += "Scalaz Bintray Repo" at "https://dl.bintray.com/scalaz/releases"
 )
 
 // Automatic code formatting

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,8 @@
 
 dir=../install_icd
 
-test -d $dir || mkdir -p $dir/{bin,lib,conf}
+test -d $dir || \
+    for i in bin lib conf; do mkdir -p $dir/$i; done
 sbt stage "project root" stage
 for i in bin lib ; do cp -f */target/universal/stage/$i/* $dir/$i/; done
 for i in bin lib conf ; do cp -f icd-web/icd-web-server/target/universal/stage/$i/* $dir/$i/; done


### PR DESCRIPTION
Just starting to play with this at HIA using an Ubuntu 14.04 system and ran into minor issues.

The install script uses /bin/sh which defaults to dash on my system, and does not recognize the bash brace expansion when creating the install directories. I switched to a more generic for loop.

Also, sbt complained that it couldn't resolve a dependency, so I added in a resolver as suggested here: http://stackoverflow.com/questions/27923223/unresolved-dependency-with-specs2-scalaz-stream-0-5a