### PR TITLE
Enfoce self-closing tags.

### DIFF
--- a/icd/src/main/scala/csw/services/icd/html/HtmlMarkup.scala
+++ b/icd/src/main/scala/csw/services/icd/html/HtmlMarkup.scala
@@ -4,6 +4,7 @@ import java.util.UUID
 
 import org.jsoup.Jsoup
 import org.jsoup.safety.Whitelist
+import org.jsoup.nodes.Document.OutputSettings
 
 import scalatags.Text.all._
 import scalatags.Text.TypedTag
@@ -79,8 +80,11 @@ object HtmlMarkup {
         Long.MaxValue
       ) // last arg is to avoid pegdown timeouts
 
+      // Enforce self-closing tags (e.g. for <img> tags) so that PDF generator will not fail.
+      val os = new OutputSettings().syntax(OutputSettings.Syntax.xml)
+
       // Convert markdown to HTML, then clean it up with jsoup to avoid issues with the pdf generator (and for security)
-      Jsoup.clean(pd.markdownToHtml(stripLeadingWs(gfm)), Whitelist.basicWithImages())
+      Jsoup.clean(pd.markdownToHtml(stripLeadingWs(gfm)), "", Whitelist.basicWithImages(), os)
     }
   }
 


### PR DESCRIPTION
PDF generation by "icd" command fails if a tag does not have the corresponding closure tag (e.g. <img>) as reported in https://github.com/tmtsoftware/icd/issues/32. This commit solves that problem by enforcing self-closure tags when "icd" command generates HTML as an intermediate product.